### PR TITLE
Batch all URLs at once instead of spawning a process for each URL

### DIFF
--- a/scrapper.py
+++ b/scrapper.py
@@ -62,18 +62,19 @@ def main():
 
 
 def download_urls():
-    for value in url:
-        subprocess.call(["gallery-dl",
-                         value,
-                         "--dest",
-                         args.directory,
-                         "--verbose",
-                         "--write-log",
-                         os.path.join(args.directory,
-                                      "gallery-dl.log"),
-                         "--write-unsupported",
-                         os.path.join(args.directory,
-                                      "gallery-dl-unsupported.log")])
+	cmd = ["gallery-dl"]
+	for value in url:
+	        cmd.append(value)
+	cmd.append("--dest")
+	cmd.append(args.directory)
+	cmd.append("--verbose")
+	cmd.append("--write-log")
+	cmd.append(os.path.join(args.directory,
+				            "gallery-dl.log"))
+	cmd.append("--write-unsupported")
+	cmd.append(os.path.join(args.directory,
+				            "gallery-dl-unsupported.log"))
+	subprocess.call(cmd)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Kept this PR to myself for a week because I forgot about it. Does two things:

1. Stop spawning a new process for every URL. Depending on the workflow and amount of URLs, this is very wasteful, and since Python has a startup time (that arguably gets better the more often you call into it), I find that my Scheduled Tasks (cronjobs for Microsoft Windows) finish 15% faster than usual with this patch applied.

2. Logging was pretty much broken, since gallery-dl always opened text files with `write` instead of `append`. Meaning you'd only get the last URL instead of all of them. By batching the URLs, this effectively solves the issue as only one process will be spawned that needs to write to that file. (As long as you aren't doing two different subreddits in the same folder, or something similar)

In this future this also could allow running multiple instances on different threads by splitting up the batch to speedup downloading since gallery-dl does not support this natively.